### PR TITLE
Add ci to run unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Unit tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  Tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20", "18", "16"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Since we are using this library in a project running in production, I would like to propose to add some github actions to at least run unit tests on the supported node versions.